### PR TITLE
deprecate getFolderContents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.10", "3.11"]
-        plone: ["60"]
+        python: ["3.11", "3.12"]
+        plone: ["60", "61"]
     steps:
       - uses: actions/checkout@v3
       - name: Cache eggs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt -c constraints_plone${{ matrix.plone }}.txt
+          pip install -r requirements_plone${{ matrix.plone }}.txt
           cp test_plone${{ matrix.plone }}.cfg buildout.cfg
       - name: Install buildout
         run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 1.0.9 (unreleased)
 ------------------
 
+- deprecate getFolderContents
+  [mamico]
 - Stampa pdf, aggiunta gestione campi lista
   [mamico]
 

--- a/constraints_plone61.txt
+++ b/constraints_plone61.txt
@@ -1,0 +1,6 @@
+-c https://dist.plone.org/release/6.1-latest/constraints.txt
+
+tox==4.3.5
+isort>=5
+black==22.8.0
+flake8==5.0.4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
+# import sys
+# import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/requirements_plone61.txt
+++ b/requirements_plone61.txt
@@ -1,0 +1,3 @@
+-c constraints_plone61.txt
+setuptools
+zc.buildout

--- a/src/iosanita/contenttypes/__init__.py
+++ b/src/iosanita/contenttypes/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Init and utils."""
-from zope.i18nmessageid import MessageFactory
 
+from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory("iosanita.contenttypes")

--- a/src/iosanita/contenttypes/browser/export_view.py
+++ b/src/iosanita/contenttypes/browser/export_view.py
@@ -18,7 +18,6 @@ import importlib.resources
 import logging
 import re
 
-
 logger = logging.getLogger(__name__)
 
 fontools_logger = logging.getLogger("fontTools.subset")

--- a/src/iosanita/contenttypes/browser/searchblock.py
+++ b/src/iosanita/contenttypes/browser/searchblock.py
@@ -17,7 +17,6 @@ from zope.interface import implementer
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/iosanita/contenttypes/events/common.py
+++ b/src/iosanita/contenttypes/events/common.py
@@ -6,7 +6,6 @@ from Products.CMFPlone.interfaces import ISelectableConstrainTypes
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/iosanita/contenttypes/interfaces/__init__.py
+++ b/src/iosanita/contenttypes/interfaces/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Module where all interfaces, events and exceptions live."""
+
 from redturtle.volto.interfaces import IRedturtleVoltoLayer
 from zope.interface import Interface
 

--- a/src/iosanita/contenttypes/locales/update.py
+++ b/src/iosanita/contenttypes/locales/update.py
@@ -4,7 +4,6 @@ import os
 import pkg_resources
 import subprocess
 
-
 domain = "iosanita.contenttypes"
 os.chdir(pkg_resources.resource_filename(domain, ""))
 os.chdir("../../../")

--- a/src/iosanita/contenttypes/restapi/serializers/summary.py
+++ b/src/iosanita/contenttypes/restapi/serializers/summary.py
@@ -15,7 +15,6 @@ from zope.interface import Interface
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/iosanita/contenttypes/restapi/services/modulistica_items/get.py
+++ b/src/iosanita/contenttypes/restapi/services/modulistica_items/get.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from iosanita.contenttypes.interfaces.cartella_modulistica import ICartellaModulistica
+from plone import api
 from plone.dexterity.utils import iterSchemata
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import IFieldSerializer
@@ -39,7 +40,7 @@ class ModulisticaItems(object):
         if context is None:
             context = self.context
         res = []
-        for brain in context.getFolderContents():
+        for brain in api.content.find(context=context, depth=1):
             if brain.portal_type == "Document" and (
                 brain.getId == "immagini" or brain.getId == "documenti"
             ):

--- a/src/iosanita/contenttypes/restapi/services/view_extra_data/extractor.py
+++ b/src/iosanita/contenttypes/restapi/services/view_extra_data/extractor.py
@@ -19,7 +19,6 @@ from zope.interface import Interface
 from zope.intid.interfaces import IIntIds
 from zope.security import checkPermission
 
-
 LIMIT = 25
 
 

--- a/src/iosanita/contenttypes/setuphandlers.py
+++ b/src/iosanita/contenttypes/setuphandlers.py
@@ -8,7 +8,6 @@ from zope.interface import implementer
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 DEFAULT_PROFILE = "profile-iosanita.contenttypes:default"
 

--- a/src/iosanita/contenttypes/tests/test_ct_bando.py
+++ b/src/iosanita/contenttypes/tests/test_ct_bando.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_cartella_modulistica.py
+++ b/src/iosanita/contenttypes/tests/test_ct_cartella_modulistica.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 # from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api
@@ -11,7 +12,6 @@ from plone.restapi.testing import RelativeSession
 from transaction import commit
 
 import unittest
-
 
 # from Products.CMFPlone.interfaces import ISelectableConstrainTypes
 

--- a/src/iosanita/contenttypes/tests/test_ct_come_fare_per.py
+++ b/src/iosanita/contenttypes/tests/test_ct_come_fare_per.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_ct_documento.py
+++ b/src/iosanita/contenttypes/tests/test_ct_documento.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_event.py
+++ b/src/iosanita/contenttypes/tests/test_ct_event.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_modulo.py
+++ b/src/iosanita/contenttypes/tests/test_ct_modulo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_ct_news.py
+++ b/src/iosanita/contenttypes/tests/test_ct_news.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_persona.py
+++ b/src/iosanita/contenttypes/tests/test_ct_persona.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_servizio.py
+++ b/src/iosanita/contenttypes/tests/test_ct_servizio.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_step.py
+++ b/src/iosanita/contenttypes/tests/test_ct_step.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_struttura.py
+++ b/src/iosanita/contenttypes/tests/test_ct_struttura.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_ct_uo.py
+++ b/src/iosanita/contenttypes/tests/test_ct_uo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api

--- a/src/iosanita/contenttypes/tests/test_custom_indexes.py
+++ b/src/iosanita/contenttypes/tests/test_custom_indexes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from plone import api
 from plone.app.dexterity.behaviors.metadata import IDublinCore

--- a/src/iosanita/contenttypes/tests/test_custom_validations.py
+++ b/src/iosanita/contenttypes/tests/test_custom_validations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_serializer_summary.py
+++ b/src/iosanita/contenttypes/tests/test_serializer_summary.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_struttura_correlata.py
+++ b/src/iosanita/contenttypes/tests/test_struttura_correlata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_taxonomies_custom_metadata.py
+++ b/src/iosanita/contenttypes/tests/test_taxonomies_custom_metadata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_uo_correlata.py
+++ b/src/iosanita/contenttypes/tests/test_uo_correlata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import INTEGRATION_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/tests/test_view_extra_data.py
+++ b/src/iosanita/contenttypes/tests/test_view_extra_data.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from iosanita.contenttypes.testing import RESTAPI_TESTING
 from plone import api
 from plone.app.testing import setRoles

--- a/src/iosanita/contenttypes/upgrades/__init__.py
+++ b/src/iosanita/contenttypes/upgrades/__init__.py
@@ -2,5 +2,4 @@
 
 import logging
 
-
 logger = logging.getLogger("iosanita.contenttypes")

--- a/src/iosanita/contenttypes/upgrades/v1001.py
+++ b/src/iosanita/contenttypes/upgrades/v1001.py
@@ -4,7 +4,6 @@ from . import logger
 from iosanita.contenttypes.events.common import SUBFOLDERS_MAPPING
 from plone import api
 
-
 # from plone import api
 
 

--- a/src/iosanita/contenttypes/utils.py
+++ b/src/iosanita/contenttypes/utils.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/test_plone61.cfg
+++ b/test_plone61.cfg
@@ -6,3 +6,4 @@ extends =
     base.cfg
 
 [versions]
+setuptools =

--- a/test_plone61.cfg
+++ b/test_plone61.cfg
@@ -1,0 +1,8 @@
+[buildout]
+
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.1.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+    base.cfg
+
+[versions]


### PR DESCRIPTION
Remove deprecated `getFolderContents()` call, which is no longer available in Plone 6.1. Replaced with `api.content.find(context=context, depth=1)` as the modern equivalent.